### PR TITLE
update goreleaser from 1.21.2 to

### DIFF
--- a/goreleaser/run.sh
+++ b/goreleaser/run.sh
@@ -15,7 +15,7 @@
 set -o pipefail
 export BASE="$(readlink -f "$(dirname "$0")/..")"
 
-VERSION_GOREL="1.21.2"
+VERSION_GOREL=""
 FLAGS=()
 
 function setup_config {


### PR DESCRIPTION
Updating tool `goreleaser`:

- Bumping **version** from `1.21.2` to ``.

Pull request auto-generated by [pr-version-updater](https://github.com/lrstanley/.github/blob/master/.github/workflows/lang-go-lint.yml) action.