### PR TITLE
update p2 from r15 to r18

### DIFF
--- a/readme/run.sh
+++ b/readme/run.sh
@@ -4,7 +4,7 @@
 # TODO: this could probably be a simple go cli tool, rather than a bash script.
 # or maybe its own action?
 
-P2_VERSION="r15"
+P2_VERSION="r18"
 
 set -o pipefail
 export BASE=$(readlink -f "$(dirname "$0")/..")


### PR DESCRIPTION
Updating tool [`p2`](https://github.com/wrouesnel/p2cli):

- Bumping **version** from [`r15`](https://github.com/wrouesnel/p2cli/releases/tag/r15) to [`r18`](https://github.com/wrouesnel/p2cli/releases/tag/r18).

Release notes: [link](https://github.com/wrouesnel/p2cli/releases/tag/r18)

Pull request auto-generated by [pr-version-updater](https://github.com/lrstanley/.github/blob/master/.github/workflows/composite-pr-version-updater/action.yml) and [meta-updaters](https://github.com/lrstanley/.github/blob/master/.github/workflows/meta-updaters.yml) action.