### PR TITLE
update goreleaser from 1.26.2 to 2.0.0

### DIFF
--- a/goreleaser/run.sh
+++ b/goreleaser/run.sh
@@ -15,7 +15,7 @@
 set -o pipefail
 export BASE="$(readlink -f "$(dirname "$0")/..")"
 
-VERSION_GOREL="1.26.2"
+VERSION_GOREL="2.5.0"
 FLAGS=()
 
 function setup_config {


### PR DESCRIPTION
Updating tool [`goreleaser`](https://github.com/goreleaser/goreleaser):

- Bumping **version** from [`1.26.2`](https://github.com/goreleaser/goreleaser/releases/tag/1.26.2) to [`2.0.0`](https://github.com/goreleaser/goreleaser/releases/tag/2.0.0).

Release notes: [link](https://github.com/goreleaser/goreleaser/releases/tag/2.0.0)

Pull request auto-generated by [pr-version-updater](https://github.com/lrstanley/.github/blob/master/.github/workflows/composite-pr-version-updater/action.yml) and [meta-updaters](https://github.com/lrstanley/.github/blob/master/.github/workflows/meta-updaters.yml) action.