### PR TITLE
update svu from 1.12.0 to 2.0.1

### DIFF
--- a/scripts/install-svu.sh
+++ b/scripts/install-svu.sh
@@ -8,7 +8,7 @@ if [ -f "/usr/local/bin/svu" ]; then
 	exit 0
 fi
 
-SVU_VERSION="1.12.0"
+SVU_VERSION="2.0.1"
 
 echo "installing svu ${SVU_VERSION}"
 curl -sSL "https://github.com/caarlos0/svu/releases/download/v${SVU_VERSION}/svu_${SVU_VERSION}_linux_amd64.tar.gz" \


### PR DESCRIPTION
Updating tool [`svu`](https://github.com/caarlos0/svu):

- Bumping **version** from [`1.12.0`](https://github.com/caarlos0/svu/releases/tag/1.12.0) to [`2.0.1`](https://github.com/caarlos0/svu/releases/tag/2.0.1).

Release notes: [link](https://github.com/caarlos0/svu/releases/tag/2.0.1)

Pull request auto-generated by [pr-version-updater](https://github.com/lrstanley/.github/blob/master/.github/workflows/composite-pr-version-updater/action.yml) and [meta-updaters](https://github.com/lrstanley/.github/blob/master/.github/workflows/meta-updaters.yml) action.