### PR TITLE
update golangci-lint from 1.59.1 to 1.60.1

### DIFF
--- a/scripts/install-golangci-lint.sh
+++ b/scripts/install-golangci-lint.sh
@@ -3,7 +3,7 @@
 
 set -o pipefail
 
-GCI_VERSION="1.59.1"
+GCI_VERSION="1.60.1"
 
 echo "installing golangci-lint ${GCI_VERSION}"
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin "v${GCI_VERSION}"


### PR DESCRIPTION
Updating tool [`golangci-lint`](https://github.com/golangci/golangci-lint):

- Bumping **version** from [`1.59.1`](https://github.com/golangci/golangci-lint/releases/tag/1.59.1) to [`1.60.1`](https://github.com/golangci/golangci-lint/releases/tag/1.60.1).

Release notes: [link](https://github.com/golangci/golangci-lint/releases/tag/1.60.1)

Pull request auto-generated by [pr-version-updater](https://github.com/lrstanley/.github/blob/master/.github/workflows/composite-pr-version-updater/action.yml) and [meta-updaters](https://github.com/lrstanley/.github/blob/master/.github/workflows/meta-updaters.yml) action.